### PR TITLE
Remove deprecated "name" attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Allows you to dismiss Mycroft verbally, in case of accidental activation, or if 
 ## Credits
 @ChanceNCounter
 @krisgesling
+@AIDungeonWiXAnon
 
 ## Category
 Configuration

--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -1,5 +1,4 @@
 {
-    "name": "Dismissal",
     "skillMetadata": {
         "sections": [
             {


### PR DESCRIPTION
Not a big deal, but should clean up the deprecation warning generated when loading the settings.