### PR TITLE
Add default setting value to ensure tests pass

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,7 +13,7 @@ class DismissalSkill(MycroftSkill):
 
     @intent_handler(IntentBuilder('dismiss.mycroft').require('Nevermind'))
     def handle_dismiss_intent(self, message):
-        if self.settings.get('verbal_feedback_enabled'):
+        if self.settings.get('verbal_feedback_enabled', True):
             self.speak_dialog('dismissed')
         self.log.info("User dismissed Mycroft.")
 


### PR DESCRIPTION
Hey Chance, just caught this while testing for the 20.08 release. Not critical but would avoid it getting flagged in the future.

When running in a test environment, the Skill may not have received its settings when the first test runs. In this instance `verbal_feedback_endabled` will be None and no dialog will be spoken causing the test to fail.

This adds the existing default from `settingsmeta.json` into the check.