### PR TITLE
add "cancel" as dismissal word

### DIFF
--- a/vocab/en-us/Nevermind.voc
+++ b/vocab/en-us/Nevermind.voc
@@ -7,3 +7,4 @@ go away
 nothing
 ignore
 abort
+cancel


### PR DESCRIPTION
Upstream decided not to include this in their stop action:

https://github.com/MycroftAI/skill-stop/pull/47#issuecomment-1060089552

Hence it's save for this intent.